### PR TITLE
fixing new-plugin CLI error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/packages/new-plugin/src/cli.js
+++ b/packages/new-plugin/src/cli.js
@@ -60,8 +60,7 @@ async function getRemoteGitUrl() {
   return "";
 }
 
-async function getGitHttpsUrl(gitUrl) {
-  gitUrl = await gitUrl;
+function getGitHttpsUrl(gitUrl) {
   gitUrl = gitUrl.replace("git+", "");
   gitUrl = gitUrl.replace(".git", "");
   return gitUrl;
@@ -147,9 +146,10 @@ async function runPrompts(cwdInfo) {
   // If not in the jspsych-contrib repository, ask for the path to the README.md file
   let readmePath;
   if (!cwdInfo.isContribRepo) {
+    const remoteGitUrl = await getRemoteGitUrl();
     readmePath = await input({
       message: "Enter the path to the README.md file for this plugin package [Optional]:",
-      default: `${ await getGitHttpsUrl(await getRemoteGitUrl())}/plugin-${name}/README.md`, // '/plugin-${name}/README.md' if not a Git repository
+      default: `${getGitHttpsUrl(remoteGitUrl)}/plugin-${name}/README.md`, // '/plugin-${name}/README.md' if not a Git repository
     });
   } else {
     readmePath = `https://github.com/jspsych/jspsych-contrib/packages/plugin-${name}/README.md`;
@@ -189,7 +189,7 @@ async function processAnswers(answers) {
     ? path.relative(repoRoot, process.cwd())
     : "./";
   const gitRootUrl = await getRemoteGitRootUrl();
-  const gitRootHttpsUrl = await getGitHttpsUrl(gitRootUrl);
+  const gitRootHttpsUrl = getGitHttpsUrl(gitRootUrl);
 
   function processTemplate() {
     return src(`${templatesDir}/plugin-template-${answers.language}/**/*`)

--- a/packages/new-plugin/src/cli.js
+++ b/packages/new-plugin/src/cli.js
@@ -60,7 +60,8 @@ async function getRemoteGitUrl() {
   return "";
 }
 
-function getGitHttpsUrl(gitUrl) {
+async function getGitHttpsUrl(gitUrl) {
+  gitUrl = await gitUrl;
   gitUrl = gitUrl.replace("git+", "");
   gitUrl = gitUrl.replace(".git", "");
   return gitUrl;
@@ -148,7 +149,7 @@ async function runPrompts(cwdInfo) {
   if (!cwdInfo.isContribRepo) {
     readmePath = await input({
       message: "Enter the path to the README.md file for this plugin package [Optional]:",
-      default: `${getGitHttpsUrl(await getRemoteGitUrl())}/plugin-${name}/README.md`, // '/plugin-${name}/README.md' if not a Git repository
+      default: `${ await getGitHttpsUrl(await getRemoteGitUrl())}/plugin-${name}/README.md`, // '/plugin-${name}/README.md' if not a Git repository
     });
   } else {
     readmePath = `https://github.com/jspsych/jspsych-contrib/packages/plugin-${name}/README.md`;
@@ -188,7 +189,7 @@ async function processAnswers(answers) {
     ? path.relative(repoRoot, process.cwd())
     : "./";
   const gitRootUrl = await getRemoteGitRootUrl();
-  const gitRootHttpsUrl = getGitHttpsUrl(gitRootUrl);
+  const gitRootHttpsUrl = await getGitHttpsUrl(gitRootUrl);
 
   function processTemplate() {
     return src(`${templatesDir}/plugin-template-${answers.language}/**/*`)


### PR DESCRIPTION
I haven't tested this yet, but I think this will fix the issue. 

When running the CLI currently it errors out every time because the `getGitHttpsUrl` function is passed a promise, but isn't expecting one, so it gets processed as undefined, crashing things out. I have changed `getGitHttpsUrl` to an async function and added a step to consume the promise first to fix this.