### PR TITLE
fix bug for remotes url detection

### DIFF
--- a/.changeset/late-cups-leave.md
+++ b/.changeset/late-cups-leave.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/new-timeline": patch
+---
+
+Fix bug in detecting whether repo has jspsych-timelines as a remote


### PR DESCRIPTION
This changes the implementation of getting the https url for the remotes. It only applies to the timelines tool. We should consider applying the fix to the other tools as well.