### PR TITLE
Change how repositories are IDed using `name` field in `package.json`

### DIFF
--- a/.changeset/modern-countries-repeat.md
+++ b/.changeset/modern-countries-repeat.md
@@ -1,0 +1,7 @@
+---
+"@jspsych/new-extension": patch
+"@jspsych/new-timeline": patch
+"@jspsych/new-plugin": patch
+---
+
+Change the strategy for detecting when commands are run inside the official repos

--- a/packages/new-timeline/src/cli.js
+++ b/packages/new-timeline/src/cli.js
@@ -101,17 +101,37 @@ function getCamelCaseName(input) {
   return input;
 }
 
+async function detectTimelinesRepo() {
+  const repoRoot = await getRepoRoot();
+  if (repoRoot) {
+    const packageJsonPath = path.join(repoRoot, "package.json");
+
+    // If package.json doesn't exist at the root, it cannot be the timelines repo.
+    if (!fs.existsSync(packageJsonPath)) {
+      return false;
+    }
+
+    // If package.json exists, try to read and parse it.
+    try {
+      const packageJsonContent = fs.readFileSync(packageJsonPath, "utf-8");
+      const packageJson = JSON.parse(packageJsonContent);
+      return packageJson.name === "@jspsych/jspsych-timelines";
+    } catch (error) {
+      // Log an error if reading or parsing an existing package.json fails.
+      console.error("Error reading or parsing package.json:", error);
+      return false;
+    }
+  }
+  // Return false if not in a git repo or repoRoot couldn't be determined.
+  return false;
+}
+
 async function getCwdInfo() {
   const isRepo = await git.checkIsRepo();
   let isTimelinesRepo;
   // Check if current directory is the jspsych-timelines repository
   if (isRepo) {
-    const remotes = await git.getRemotes(true);
-    isTimelinesRepo = remotes.some((remote) => {
-      const remoteUrl = remote.refs.fetch;
-      const httpsUrl = getGitHttpsUrl(remoteUrl);
-      return httpsUrl.includes("github.com/jspsych/jspsych-timelines");
-    });
+    isTimelinesRepo = await detectTimelinesRepo();
     if (isTimelinesRepo) {
       return {
         isRepo: isRepo,


### PR DESCRIPTION
This changes the strategy for detecting whether the tools are run in jspsych-contrib or jspsych-timelines by using the name field of the package.json in the root of the repo.