### PR TITLE
Fix JS scaffold build + add CLI template smoke test

### DIFF
--- a/.changeset/fix-js-template-build.md
+++ b/.changeset/fix-js-template-build.md
@@ -1,0 +1,11 @@
+---
+"@jspsych/new-plugin": patch
+"@jspsych/new-extension": patch
+"@jspsych/new-timeline": patch
+---
+
+Fix the JavaScript template build so generated packages build out of the box:
+
+- Add the Babel toolchain (`@babel/cli`, `@babel/core`, `@babel/preset-env`, `babel-preset-minify`) to the JS templates' `devDependencies`. The `build` script invokes `babel` but none of these were installed, so `npm run build` failed with a "babel not found" error after a fresh `npm install`.
+- Point the `build` script at `src/index.js` (where the source actually lives) instead of a non-existent `index.js` at the package root, which previously caused `babel: index.js does not exist`.
+- Update the `files` array to publish `src` instead of the non-existent `index.js`, matching the TypeScript templates.

--- a/.github/workflows/smoke-test-templates.yml
+++ b/.github/workflows/smoke-test-templates.yml
@@ -1,0 +1,85 @@
+name: CLI Template Smoke Test
+
+# End-to-end check that every scaffolding CLI produces a package that
+# installs and builds from a clean checkout. Catches broken template
+# package.json scripts/dependencies before they reach published CLIs.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "packages/new-plugin/**"
+      - "packages/new-extension/**"
+      - "packages/new-timeline/**"
+      - ".github/workflows/smoke-test-templates.yml"
+  workflow_dispatch:
+
+jobs:
+  scaffold-and-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cli: [new-plugin, new-extension, new-timeline]
+        language: [ts, js]
+    name: ${{ matrix.cli }} (${{ matrix.language }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      # Installs the CLI packages' own dependencies (gulp, commander, etc.)
+      # so the generators can run. npm ci is intentionally avoided: the
+      # scaffolded package below does a fresh, isolated npm install.
+      - name: Install workspace dependencies
+        run: npm install
+
+      - name: Scaffold a package
+        id: scaffold
+        run: |
+          set -euo pipefail
+          WORKDIR="$(mktemp -d)"
+          echo "workdir=$WORKDIR" >> "$GITHUB_OUTPUT"
+          case "${{ matrix.cli }}" in
+            new-plugin)    DIR="plugin-smoke-test" ;;
+            new-extension) DIR="extension-smoke-test" ;;
+            new-timeline)  DIR="smoke-test" ;;
+          esac
+          echo "pkgdir=$WORKDIR/$DIR" >> "$GITHUB_OUTPUT"
+          cd "$WORKDIR"
+          node "$GITHUB_WORKSPACE/packages/${{ matrix.cli }}/src/cli.js" \
+            --name "smoke-test" \
+            --description "CI smoke test package" \
+            --author "jsPsych CI" \
+            --language "${{ matrix.language }}"
+          if [ ! -d "$WORKDIR/$DIR" ]; then
+            echo "::error::CLI did not create expected package directory: $DIR"
+            ls -la "$WORKDIR"
+            exit 1
+          fi
+
+      - name: Install scaffolded package
+        working-directory: ${{ steps.scaffold.outputs.pkgdir }}
+        run: npm install
+
+      - name: Build scaffolded package
+        working-directory: ${{ steps.scaffold.outputs.pkgdir }}
+        run: npm run build
+
+      - name: Verify build output
+        working-directory: ${{ steps.scaffold.outputs.pkgdir }}
+        run: |
+          set -euo pipefail
+          OUT="dist/index.browser.min.js"
+          if [ ! -s "$OUT" ]; then
+            echo "::error::Expected build artifact missing or empty: $OUT"
+            ls -la dist || echo "(no dist directory)"
+            exit 1
+          fi
+          echo "Built $OUT ($(wc -c < "$OUT" | tr -d ' ') bytes)"

--- a/packages/new-extension/templates/extension-template-js/package.json
+++ b/packages/new-extension/templates/extension-template-js/package.json
@@ -4,11 +4,11 @@
   "description": "{description}",
   "unpkg": "dist/index.browser.min.js",
   "files": [
-    "index.js",
+    "src",
     "dist"
   ],
   "scripts": {
-    "build": "babel index.js --presets @babel/preset-env,minify --source-maps --out-file dist/index.browser.min.js",
+    "build": "babel src/index.js --presets @babel/preset-env,minify --source-maps --out-file dist/index.browser.min.js",
     "build:watch": "npm run build -- --watch"
   },
   "repository": {
@@ -36,6 +36,10 @@
     "@citation-js/plugin-cff": "^0.6.1"
   },
   "devDependencies": {
-    "@jspsych/config": "^3.2.2"
+    "@babel/cli": "^7.28.0",
+    "@babel/core": "^7.28.0",
+    "@babel/preset-env": "^7.28.0",
+    "@jspsych/config": "^3.2.2",
+    "babel-preset-minify": "^0.5.2"
   }
 }

--- a/packages/new-plugin/templates/plugin-template-js/package.json
+++ b/packages/new-plugin/templates/plugin-template-js/package.json
@@ -4,11 +4,11 @@
   "description": "{description}",
   "unpkg": "dist/index.browser.min.js",
   "files": [
-    "index.js",
+    "src",
     "dist"
   ],
   "scripts": {
-    "build": "babel index.js --presets @babel/preset-env,minify --source-maps --out-file dist/index.browser.min.js",
+    "build": "babel src/index.js --presets @babel/preset-env,minify --source-maps --out-file dist/index.browser.min.js",
     "build:watch": "npm run build -- --watch"
   },
   "repository": {
@@ -36,6 +36,10 @@
     "@citation-js/plugin-cff": "^0.6.1"
   },
   "devDependencies": {
-    "@jspsych/config": "^3.2.2"
+    "@babel/cli": "^7.28.0",
+    "@babel/core": "^7.28.0",
+    "@babel/preset-env": "^7.28.0",
+    "@jspsych/config": "^3.2.2",
+    "babel-preset-minify": "^0.5.2"
   }
 }

--- a/packages/new-timeline/templates/timeline-template-js/package.json
+++ b/packages/new-timeline/templates/timeline-template-js/package.json
@@ -1,35 +1,39 @@
 {
-    "name": "{npmPackageName}",
-    "version": "0.0.1",
-    "description": "{description}",
-    "unpkg": "dist/index.browser.min.js",
-    "files": [
-      "index.js",
-      "dist"
-    ],
-    "scripts": {
-      "build": "babel index.js --presets @babel/preset-env,minify --source-maps --out-file dist/index.browser.min.js",
-      "build:watch": "npm run build -- --watch"
-    },
-    "repository": {
-      "type": "git",
-      "url": "{gitRootUrl}",
-      "directory": "{packageDir}"
-    },
-    "keywords": [
-      "jsPsych"
-    ],
-    "author": {
-      "name": "{author}",
-      "url": "{authorUrl}"
-    },
-    "license": "MIT",
-    "bugs": {
-      "url": "{gitRootHttpsUrl}/issues"
-    },
-    "homepage": "{documentationUrl}",
-    "devDependencies": {
-      "@jspsych/config": "^3.2.2",
-      "jspsych": "^8.0.0"
-    }
+  "name": "{npmPackageName}",
+  "version": "0.0.1",
+  "description": "{description}",
+  "unpkg": "dist/index.browser.min.js",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "scripts": {
+    "build": "babel src/index.js --presets @babel/preset-env,minify --source-maps --out-file dist/index.browser.min.js",
+    "build:watch": "npm run build -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "{gitRootUrl}",
+    "directory": "{packageDir}"
+  },
+  "keywords": [
+    "jsPsych"
+  ],
+  "author": {
+    "name": "{author}",
+    "url": "{authorUrl}"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "{gitRootHttpsUrl}/issues"
+  },
+  "homepage": "{documentationUrl}",
+  "devDependencies": {
+    "@babel/cli": "^7.28.0",
+    "@babel/core": "^7.28.0",
+    "@babel/preset-env": "^7.28.0",
+    "@jspsych/config": "^3.2.2",
+    "babel-preset-minify": "^0.5.2",
+    "jspsych": "^8.0.0"
   }
+}


### PR DESCRIPTION
## Summary

A user hit `babel: command not found` running `npm run build` on a freshly scaffolded **new-plugin** JS package. Root cause was a broken JavaScript template, and validating the fix surfaced a second build bug — so this PR fixes both across all three generators and adds CI to keep it from regressing.

### Template fixes (all three JS templates)
- **Missing Babel toolchain:** the `build` script invokes `babel` with `@babel/preset-env` + the `minify` preset, but none of `@babel/cli`, `@babel/core`, `@babel/preset-env`, `babel-preset-minify` were in `devDependencies`. After a clean `npm install` the `babel` binary didn't exist → "babel not found". Pinned to the Babel 7 line, which is compatible with the (2022-era) `babel-preset-minify`.
- **Wrong source path:** `build` compiled `index.js` at the package root, but the source ships at `src/index.js` (like the TS templates) → `babel: index.js does not exist`. Fixed the path and updated `files` to publish `src` instead of the non-existent `index.js`.

Affects `@jspsych/new-plugin`, `@jspsych/new-extension`, `@jspsych/new-timeline` (patch changeset included). TS templates were already fine.

### New CI: `CLI Template Smoke Test`
End-to-end workflow that, for a 3×2 matrix (each CLI × ts/js), scaffolds a package non-interactively, then runs `npm install` + `npm run build` in the **generated** package and asserts `dist/index.browser.min.js` is produced. This is what caught the second bug. Runs on PRs touching the CLI packages, pushes to `main`, and manual dispatch.

## Testing
Ran the full scaffold → install → build flow locally for all six combinations — all pass:

```
new-plugin     ts/js -> plugin-smoke-test      OK
new-extension  ts/js -> extension-smoke-test   OK
new-timeline   ts/js -> smoke-test             OK
```

## Note (out of scope)
`package-lock.json` is out of sync — `npm ci` fails on missing `@esbuild/*` platform optional deps (pre-existing, also affects `release.yml`). Happy to regenerate the lockfile in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)