### PR TITLE
Use ParameterType string map for data table types

### DIFF
--- a/packages/autodoc/src/parsers/utils.ts
+++ b/packages/autodoc/src/parsers/utils.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
 import { ExampleInfo, ParameterInfo } from "../types/info.js";
+import { PARAMETER_TYPE_MAP } from "../renderers/utils.js";
 
 // --- PARSE SRC FILE UTILS ---
 
@@ -48,7 +49,8 @@ function extractParameter(node: ts.ObjectLiteralExpression, source: ts.SourceFil
     switch (key) {
       case "type": {
         if (ts.isPropertyAccessExpression(prop.initializer)) {
-          result.type = prop.initializer.getText(source);
+          const raw = prop.initializer.getText(source);
+          result.type = PARAMETER_TYPE_MAP[raw] ?? raw;
         }
         break;
       }

--- a/packages/autodoc/src/renderers/plugin.ts
+++ b/packages/autodoc/src/renderers/plugin.ts
@@ -1,22 +1,7 @@
 import { PluginInfo, SectionTemplate } from "../types/info.js";
-import { renderParameterRow, renderDataRow, renderSections, topParameterChart, topDataChart } from "./utils.js";
+import { renderParameterRow, renderDataRow, renderSections, topParameterChart, topDataChart, PARAMETER_TYPE_MAP } from "./utils.js";
 
-const stringifyTypeMap: Record<string, string> = {
-  "ParameterType.STRING": "string",
-  "ParameterType.INT": "integer",
-  "ParameterType.FLOAT": "float",
-  "ParameterType.BOOL": "boolean",
-  "ParameterType.FUNCTION": "function",
-  "ParameterType.KEY": "key",
-  "ParameterType.KEYS": "keys",
-  "ParameterType.SELECT": "selection", //TODO: infer type from options
-  "ParameterType.HTML_STRING": "HTML string",
-  "ParameterType.IMAGE": "image file",
-  "ParameterType.AUDIO": "audio file",
-  "ParameterType.VIDEO": "video file",
-  "ParameterType.OBJECT": "object",
-  "ParameterType.COMPLEX": "object",
-};
+const stringifyTypeMap = PARAMETER_TYPE_MAP;
 
 const getTypeName = (type: string, array?: boolean): string => {
   const baseType = stringifyTypeMap[type] || type;

--- a/packages/autodoc/src/renderers/utils.ts
+++ b/packages/autodoc/src/renderers/utils.ts
@@ -18,6 +18,23 @@ export function renderSections<T>(
   );
 }
 
+export const PARAMETER_TYPE_MAP: Record<string, string> = {
+  "ParameterType.STRING": "string",
+  "ParameterType.INT": "integer",
+  "ParameterType.FLOAT": "float",
+  "ParameterType.BOOL": "boolean",
+  "ParameterType.FUNCTION": "function",
+  "ParameterType.KEY": "key",
+  "ParameterType.KEYS": "keys",
+  "ParameterType.SELECT": "selection",
+  "ParameterType.HTML_STRING": "HTML string",
+  "ParameterType.IMAGE": "image file",
+  "ParameterType.AUDIO": "audio file",
+  "ParameterType.VIDEO": "video file",
+  "ParameterType.OBJECT": "object",
+  "ParameterType.COMPLEX": "object",
+};
+
 export const topParameterChart = `| Parameter | Type | Default Value | Description |
 | --------- | ---- | ------------- | ----------- |`;
 

--- a/packages/autodoc/tests/parsers/extension.test.ts
+++ b/packages/autodoc/tests/parsers/extension.test.ts
@@ -78,16 +78,16 @@ describe('getExtensionInfo', () => {
     it('extracts data parameters', () => {
         const { mainNode: classNode } = identifyPackageType(fixtureSource);
         const info = getExtensionInfo(fixtureSource, classNode as ts.ClassDeclaration);
-        expect(info.data.data_param.type).toBe('ParameterType.FLOAT');
+        expect(info.data.data_param.type).toBe('float');
         expect(info.data.data_param.description).toBe('Data parameter description.');
-        expect(info.data.double_data.type).toBe('ParameterType.BOOL');
+        expect(info.data.double_data.type).toBe('boolean');
         expect(info.data.double_data.description).toBe('Multi-line data parameter description. It has two lines for data.');
     });
 
     it('extracts nested data parameters', () => {
         const { mainNode: classNode } = identifyPackageType(fixtureSource);
         const info = getExtensionInfo(fixtureSource, classNode as ts.ClassDeclaration);
-        expect(info.data.grid.type).toBe('ParameterType.COMPLEX');
+        expect(info.data.grid.type).toBe('object');
         expect(info.data.grid.description).toBe("Now let's have a grid.");
         expect(info.data.grid.nested).toBeDefined();
     });

--- a/packages/autodoc/tests/parsers/plugin.test.ts
+++ b/packages/autodoc/tests/parsers/plugin.test.ts
@@ -30,9 +30,9 @@ describe('getPluginInfo', () => {
     it('extracts parameters with types and descriptions', () => {
         const { mainNode: classNode } = identifyPackageType(fixtureSource);
         const info = getPluginInfo(fixtureSource, classNode as ts.ClassDeclaration);
-        expect(info.parameters.single.type).toBe('ParameterType.STRING');
+        expect(info.parameters.single.type).toBe('string');
         expect(info.parameters.single.description).toBe('Single-line description.');
-        expect(info.parameters.double_double.type).toBe('ParameterType.INT');
+        expect(info.parameters.double_double.type).toBe('integer');
         expect(info.parameters.double_double.description).toBe('Multi-line description. It has two lines for a parameter.');
     });
 
@@ -45,9 +45,9 @@ describe('getPluginInfo', () => {
     it('extracts data parameters', () => {
         const { mainNode: classNode } = identifyPackageType(fixtureSource);
         const info = getPluginInfo(fixtureSource, classNode as ts.ClassDeclaration);
-        expect(info.data.data_param.type).toBe('ParameterType.FLOAT');
+        expect(info.data.data_param.type).toBe('float');
         expect(info.data.data_param.description).toBe('Data parameter description.');
-        expect(info.data.double_data.type).toBe('ParameterType.BOOL');
+        expect(info.data.double_data.type).toBe('boolean');
         expect(info.data.double_data.description).toBe('Multi-line data parameter description. It has two lines for data.');
     });
 });

--- a/packages/autodoc/tests/renderers/__snapshots__/extension.test.ts.snap
+++ b/packages/autodoc/tests/renderers/__snapshots__/extension.test.ts.snap
@@ -7,7 +7,7 @@ exports[`extension renderer (default template) matches the rendered snapshot 1`]
 
 | Name | Type | Value |
 | ---- | ---- | ----- |
-| samples | ParameterType.OBJECT | Collected samples. |
+| samples | object | Collected samples. |
 <!-- jspsych-autodocs:data:end -->",
   "examples": "<!-- jspsych-autodocs:examples:start -->
 ## Examples
@@ -32,7 +32,7 @@ initJsPsych({
 
 | Parameter | Type | Default Value | Description |
 | --------- | ---- | ------------- | ----------- |
-| tracking | ParameterType.BOOL | \`true\` | Whether to track. |
+| tracking | boolean | \`true\` | Whether to track. |
 <!-- jspsych-autodocs:init-parameters:end -->",
   "introduction": "<!-- jspsych-autodocs:introduction:start -->
 # test-extension
@@ -61,7 +61,7 @@ var trial = {
 
 | Parameter | Type | Default Value | Description |
 | --------- | ---- | ------------- | ----------- |
-| label | ParameterType.STRING | \`undefined\` | Trial label. |
+| label | string | \`undefined\` | Trial label. |
 <!-- jspsych-autodocs:trial-parameters:end -->",
 }
 `;

--- a/packages/autodoc/tests/renderers/extension.test.ts
+++ b/packages/autodoc/tests/renderers/extension.test.ts
@@ -6,15 +6,15 @@ const info: ExtensionInfo = {
   description: "A test extension.",
   version: "1.0.0",
   initializeParameters: {
-    tracking: { type: "ParameterType.BOOL", default: "true", description: "Whether to track." },
+    tracking: { type: "boolean", default: "true", description: "Whether to track." },
   },
   onStartParameters: {
-    label: { type: "ParameterType.STRING", default: "undefined", description: "Trial label." },
+    label: { type: "string", default: "undefined", description: "Trial label." },
   },
   onLoadParameters: {},
   onFinishParameters: {},
   data: {
-    samples: { type: "ParameterType.OBJECT", default: "", description: "Collected samples." },
+    samples: { type: "object", default: "", description: "Collected samples." },
   },
   examples: {
     "Basic example": { path: "examples/basic.html", code: "initJsPsych({ extensions: [...] });" },

--- a/packages/autodoc/tests/renderers/extension.test.ts
+++ b/packages/autodoc/tests/renderers/extension.test.ts
@@ -39,6 +39,14 @@ describe("extension renderer (default template)", () => {
     expect(docs["init-parameters"]).toContain("jsPsychExtensionTestExtension");
   });
 
+  it("renders human-readable type strings in parameter and data tables", () => {
+    expect(docs["init-parameters"]).toContain("boolean");
+    expect(docs["trial-parameters"]).toContain("string");
+    expect(docs["data"]).toContain("object");
+    expect(docs["init-parameters"]).not.toContain("ParameterType");
+    expect(docs["data"]).not.toContain("ParameterType");
+  });
+
   it("matches the rendered snapshot", () => {
     expect(getExtensionDocs(info)).toMatchSnapshot();
   });

--- a/packages/autodoc/tests/renderers/plugin.test.ts
+++ b/packages/autodoc/tests/renderers/plugin.test.ts
@@ -39,6 +39,12 @@ describe("plugin renderer (default template)", () => {
     expect(docs.examples).toContain("examples/basic.html");
   });
 
+  it("maps ParameterType values to human-readable strings in the data table", () => {
+    expect(docs.data).toContain("integer");
+    expect(docs.data).toContain("string");
+    expect(docs.data).not.toContain("ParameterType");
+  });
+
   it("matches the rendered snapshot", () => {
     expect(getPluginDocs(info)).toMatchSnapshot();
   });

--- a/packages/autodoc/tests/renderers/utils.test.ts
+++ b/packages/autodoc/tests/renderers/utils.test.ts
@@ -1,5 +1,20 @@
-import { renderSections } from "../../src/renderers/utils.js";
+import { renderSections, PARAMETER_TYPE_MAP } from "../../src/renderers/utils.js";
 import { SectionTemplate } from "../../src/types/info.js";
+
+describe("PARAMETER_TYPE_MAP", () => {
+  it("maps common ParameterType values to human-readable strings", () => {
+    expect(PARAMETER_TYPE_MAP["ParameterType.BOOL"]).toBe("boolean");
+    expect(PARAMETER_TYPE_MAP["ParameterType.STRING"]).toBe("string");
+    expect(PARAMETER_TYPE_MAP["ParameterType.INT"]).toBe("integer");
+    expect(PARAMETER_TYPE_MAP["ParameterType.FLOAT"]).toBe("float");
+    expect(PARAMETER_TYPE_MAP["ParameterType.HTML_STRING"]).toBe("HTML string");
+    expect(PARAMETER_TYPE_MAP["ParameterType.COMPLEX"]).toBe("object");
+  });
+
+  it("returns undefined for unknown ParameterType values", () => {
+    expect(PARAMETER_TYPE_MAP["ParameterType.UNKNOWN"]).toBeUndefined();
+  });
+});
 
 // `renderSections` is the shared, type-agnostic wrapper behind every `get*Docs`
 // function. It does not know about any particular `*Info` shape or default


### PR DESCRIPTION
Fixes #62

Previously, the autodoc tool would use a ParameterType -> string map for the Parameters table in the generated doc, but not the Data Generated table. This PR moves the ParameterType string map from `src/renderers/plugin.ts` into `src/renderers/utils.ts`, and then imports it into both `src/renderers/plugin.ts` (for use with the Parameters table) and `src/parsers/utils.ts` (for use with the Data Generated values).

Other changes:
- Update plugin/extension parser tests to expect string-mapped params rather than `ParameterType`
- Update the extension snapshot to use string-mapped params in tables rather than `ParameterType`
- Add test for the `ParameterType` -> string map in utils
- Add tests for string-mapped params in plugin/extension renderer tests

## Example

Existing version:

```md
## Data Generated

| Name | Type | Value |
| ---- | ---- | ----- |
| pauseEvents | array of ParameterType.COMPLEX | Array of pause/unpause events. Each event is an object with a type and timestamp relative to trial onset. (`eventType`: Type of event that is being logged: either "pause" or "unpause"., `eventTime`: Timstamp for this event.) |
| restart_trial | ParameterType.BOOL | True if restart_after_pause is true and the trial was paused at some point. |
```

Generated from the PR version:

```md
## Data Generated

| Name | Type | Value |
| ---- | ---- | ----- |
| pauseEvents | array of object | Array of pause/unpause events. Each event is an object with a type and timestamp relative to trial onset. (`eventType`: Type of event that is being logged: either "pause" or "unpause"., `eventTime`: Timstamp for this event.) |
| restart_trial | boolean | True if restart_after_pause is true and the trial was paused at some point. |
```