### PR TITLE
Update new-multiplayer-adapter template for jsPsych.multiplayer namespace

### DIFF
--- a/packages/new-multiplayer-adapter/README.md
+++ b/packages/new-multiplayer-adapter/README.md
@@ -2,7 +2,7 @@
 
 This package lets you start building a [jsPsych multiplayer adapter](https://github.com/jspsych/jsPsych/blob/main/docs/developers/adapter-development.md) by simply running `npx @jspsych/new-multiplayer-adapter` from the command line.
 
-A multiplayer adapter implements jsPsych's `MultiplayerAdapter` interface and is responsible for the network I/O against a specific backend (JATOS group sessions, Firebase, a custom WebSocket server, etc.). Once written, it can be passed to `jsPsych.pluginAPI.connect()` and used by any multiplayer plugin.
+A multiplayer adapter implements jsPsych's `MultiplayerAdapter` interface and is responsible for the network I/O against a specific backend (JATOS group sessions, Firebase, a custom WebSocket server, etc.). Once written, it can be passed to `jsPsych.multiplayer.connect()` and used by any multiplayer plugin.
 
 You will be prompted to enter a name for your adapter, a description, the name of the author, an optional link to the author's GitHub profile, and an optional link to a `README.md` file. A template package containing boilerplate TypeScript code will then be generated in your current working directory.
 

--- a/packages/new-multiplayer-adapter/templates/adapter-template-ts/README.md
+++ b/packages/new-multiplayer-adapter/templates/adapter-template-ts/README.md
@@ -4,7 +4,7 @@
 
 {description}
 
-This is a [jsPsych multiplayer adapter](https://github.com/jspsych/jsPsych/blob/main/docs/developers/adapter-development.md). It implements the `MultiplayerAdapter` interface so it can be passed to `jsPsych.pluginAPI.connect()` and used by multiplayer plugins.
+This is a [jsPsych multiplayer adapter](https://github.com/jspsych/jsPsych/blob/main/docs/developers/adapter-development.md). It implements the `MultiplayerAdapter` interface so it can be passed to `jsPsych.multiplayer.connect()` and used by multiplayer plugins.
 
 ## Loading
 

--- a/packages/new-multiplayer-adapter/templates/adapter-template-ts/docs/docs-template.md
+++ b/packages/new-multiplayer-adapter/templates/adapter-template-ts/docs/docs-template.md
@@ -19,7 +19,7 @@ import {globalName} from "{npmPackageName}";
 const jsPsych = initJsPsych();
 
 // Connect the adapter before running the timeline.
-await jsPsych.pluginAPI.connect(new {globalName}(/* backend-specific options */));
+await jsPsych.multiplayer.connect(new {globalName}(/* backend-specific options */));
 
 await jsPsych.run(timeline);
 ```

--- a/packages/new-multiplayer-adapter/templates/adapter-template-ts/examples/index.html
+++ b/packages/new-multiplayer-adapter/templates/adapter-template-ts/examples/index.html
@@ -17,7 +17,7 @@
       async function run() {
         // Connect the adapter before running the timeline. Pass any backend-specific
         // options your adapter's constructor needs.
-        await jsPsych.pluginAPI.connect(new {globalName}());
+        await jsPsych.multiplayer.connect(new {globalName}());
 
         const trial = {
           type: jsPsychMultiplayerSync,

--- a/packages/new-multiplayer-adapter/templates/adapter-template-ts/src/index.ts
+++ b/packages/new-multiplayer-adapter/templates/adapter-template-ts/src/index.ts
@@ -6,7 +6,7 @@ import { GroupSessionData, MultiplayerAdapter, Unsubscribe } from "jspsych";
  * {description}
  *
  * A jsPsych multiplayer adapter implements the `MultiplayerAdapter` interface so it can be passed
- * to `jsPsych.pluginAPI.connect(new {camelCaseName}Adapter(...))`. The adapter is responsible only
+ * to `jsPsych.multiplayer.connect(new {camelCaseName}Adapter(...))`. The adapter is responsible only
  * for network I/O against a specific backend; all higher-level behavior (subscribe replay,
  * `wait()` fast-path, subscription tracking) lives in jsPsych's `MultiplayerAPI`, so it stays
  * consistent across backends.


### PR DESCRIPTION
## Summary
- Updates `new-multiplayer-adapter`'s scaffolding template to call `jsPsych.multiplayer.connect()` instead of the now-removed `jsPsych.pluginAPI.connect()`, matching the top-level `jsPsych.multiplayer` namespace introduced in [jspsych/jsPsych#3694](https://github.com/jspsych/jsPsych/pull/3694).
- Changes are confined to the generated adapter's README, docs template, example HTML, and `src/index.ts` doc comment — no logic changes, since `MultiplayerAdapter`'s interface (`connect`, `push`, `getAll`, `get`, `subscribe`, `disconnect`, `participantId`) is unaffected by the rename.

## Test plan
- [x] Ran `new-multiplayer-adapter` non-interactively to scaffold a test package and confirmed generated files reference `jsPsych.multiplayer.connect()`
- [x] Repo-wide grep confirms no remaining references to `pluginAPI.connect` or `communicate()`